### PR TITLE
Merge features/modules refactor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,10 @@ Because MM JSR uses [Grunt](https://gruntjs.com/getting-started) in build proces
 ```
 grunt dev
 ```
+or
+```
+npm run dev
+```
 
 starts development server with auto-reload. It keeps an eye on linting and returns results to console, so make sure to look at it before build!
 
@@ -26,6 +30,10 @@ starts development server with auto-reload. It keeps an eye on linting and retur
 
 ```
 grunt dist
+```
+or
+```
+npm run build
 ```
 
 builds the project to `dist` directory.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Tested browser support: Firefox (57+), Chrome (63+), Edge (41+)
 **This is development branch**. This branch has all newest features:
 
 - support for High DPI Displays (e.g. Retina displays) [by [sahithyen](https://github.com/sahithyen)]
+- updated module system
 
 ## Table of content
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "author": "Mateusz 'Soanvig' Koteja",
   "description": "Pure JS range input solution",
   "license": "MIT",
+  "scripts": {
+    "test": "jest",
+    "dev": "grunt dev",
+    "build": "grunt build"
+  },
   "files": [
     "dist/main.js",
     "dist/assets/css/main.css"
@@ -41,8 +46,5 @@
   },
   "dependencies": {
     "deepmerge": "^1.5.1"
-  },
-  "scripts": {
-    "test": "jest"
   }
 }

--- a/src/assets/js/core/core.js
+++ b/src/assets/js/core/core.js
@@ -64,7 +64,7 @@ function findClosestValue (lookupVal) {
   return id;
 }
 
-export default class {
+class Core {
   constructor () {
     // This lists all available in-object variables
     this.logger = null;
@@ -258,3 +258,8 @@ export default class {
     }
   }
 }
+
+export default {
+  name: 'core',
+  Klass: Core
+};

--- a/src/assets/js/core/eventSystem.js
+++ b/src/assets/js/core/eventSystem.js
@@ -1,6 +1,6 @@
 import Event from './event.js';
 
-export default class {
+class Eventizer {
   constructor () {
     this.store = {};
   }
@@ -43,3 +43,8 @@ export default class {
     this._dispatchEvent(name, ...args);
   }
 }
+
+export default {
+  name: 'eventizer',
+  Klass: Eventizer
+};

--- a/src/assets/js/core/renderer.js
+++ b/src/assets/js/core/renderer.js
@@ -16,7 +16,7 @@ function getSlidersWithSameValue (sliderNum) {
   return sliders;
 }
 
-export default class {
+class Renderer {
   constructor () {
     // This lists all available in-object variables
     this.logger = null;
@@ -267,3 +267,8 @@ export default class {
     this._updateBars(sliderNum, value);
   }
 }
+
+export default {
+  name: 'renderer',
+  Klass: Renderer
+};

--- a/src/assets/js/grid.js
+++ b/src/assets/js/grid.js
@@ -1,7 +1,7 @@
 import { throttle } from './helpers.js';
 import merge from 'deepmerge';
 
-export default class {
+class Grid {
   _bindEvents () {
     const id = Math.random();
     window.addEventListener('resize', () => {
@@ -105,3 +105,8 @@ export default class {
     this._bindEvents();
   }
 }
+
+export default {
+  name: 'grid',
+  Klass: Grid
+};

--- a/src/assets/js/htmlLabels.js
+++ b/src/assets/js/htmlLabels.js
@@ -1,4 +1,4 @@
-export default class {
+class HtmlLabels {
   _bindEvents () {
     // For each id of input
     this.inputs.map((input) => input.id).forEach((id, index) => {
@@ -22,3 +22,8 @@ export default class {
     this._bindEvents();
   }
 }
+
+export default {
+  name: 'htmlLabels',
+  Klass: HtmlLabels
+};

--- a/src/assets/js/inputUpdater.js
+++ b/src/assets/js/inputUpdater.js
@@ -1,4 +1,4 @@
-export default class {
+class InputUpdater {
   constructor () {
     this.input = null;
   }
@@ -21,3 +21,8 @@ export default class {
     this._bindEvents();
   }
 }
+
+export default {
+  name: 'inputUpdater',
+  Klass: InputUpdater
+};

--- a/src/assets/js/labels.js
+++ b/src/assets/js/labels.js
@@ -105,7 +105,7 @@ function updateLabel (id, real, ratio) {
   }
 }
 
-export default class {
+class Labels {
   constructor () {
     this.labels = [];
     this.minMax = [];
@@ -191,3 +191,8 @@ export default class {
     });
   }
 }
+
+export default {
+  name: 'labels',
+  Klass: Labels
+};

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -20,25 +20,16 @@ export default class {
       limit: {
         show: false
       },
-      modules: {
-        eventizer: Eventizer,
-        core: Core,
-        labels: Labels,
-        grid: Grid,
-        renderer: Renderer,
-        touchSupport: TouchSupport,
-        inputUpdater: InputUpdater,
-        htmlLabels: HtmlLabels
-      },
-      modulesOrder: [
-        'eventizer',
-        'core',
-        'labels',
-        'grid',
-        'renderer',
-        'touchSupport',
-        'inputUpdater',
-        'htmlLabels'
+      modules: {},
+      modulesArray: [
+        Eventizer,
+        Core,
+        Labels,
+        Grid,
+        Renderer,
+        TouchSupport,
+        InputUpdater,
+        HtmlLabels
       ]
     };
     this.config = merge(defaults, options);
@@ -75,9 +66,14 @@ export default class {
 
     // Install modules
     this.modules = {};
-    this.config.modulesOrder.forEach((moduleName) => {
-      if (this.config.modules[moduleName]) {
-        this.modules[moduleName] = new this.config.modules[moduleName];
+    this.config.modulesArray.forEach((module) => {
+      // Keep backward compability, because of semver
+      // Setting config.modules to false will disable module
+      if (
+        typeof this.config.modules[module.name] === 'undefined'
+        || this.config.modules[module.name]
+      ) {
+        this.modules[module.name] = new module.Klass;
       }
     });
 

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -29,12 +29,19 @@ export default class {
         touchSupport: TouchSupport,
         inputUpdater: InputUpdater,
         htmlLabels: HtmlLabels
-      }
+      },
+      modulesOrder: [
+        'eventizer',
+        'core',
+        'labels',
+        'grid',
+        'renderer',
+        'touchSupport',
+        'inputUpdater',
+        'htmlLabels'
+      ]
     };
-    this.config = merge(defaults, options, {
-      // This will overwrite arrays, instead merging them.
-      arrayMerge: (destinationArray, sourceArray) => sourceArray
-    });
+    this.config = merge(defaults, options);
 
     this.specificConfig = {
       inputUpdater: {},
@@ -66,13 +73,13 @@ export default class {
       return {};
     }
 
-    // Create modules
+    // Install modules
     this.modules = {};
-    for (const moduleName in this.config.modules) {
+    this.config.modulesOrder.forEach((moduleName) => {
       if (this.config.modules[moduleName]) {
         this.modules[moduleName] = new this.config.modules[moduleName];
       }
-    }
+    });
 
     this.specificConfig.inputUpdater.inputs = this.inputs;
     this.specificConfig.htmlLabels.inputs = this.inputs;

--- a/src/assets/js/touchSupport.js
+++ b/src/assets/js/touchSupport.js
@@ -1,6 +1,6 @@
 import { listenOn } from './helpers.js';
 
-export default class {
+class TouchSupport {
   _bindEvents () {
     const elements = [this.modules.renderer.body.sliders];
     if (this.modules.renderer.body.labels) {
@@ -39,3 +39,8 @@ export default class {
     this._bindEvents();
   }
 }
+
+export default {
+  name: 'touchSupport',
+  Klass: TouchSupport
+};


### PR DESCRIPTION
This change may be useful during splitting modules into separated repositories.

Plus it stores modules installing order in better way (array instead of object).

It preserves backward compatibility, because of semver.